### PR TITLE
Switch to Visual Studio 2019, disabled Screen Resolution Modification, added handling for the two GUID flags and added "return address" to log of interface calls

### DIFF
--- a/ddraw_logger/ddraw/Direct3D.cpp
+++ b/ddraw_logger/ddraw/Direct3D.cpp
@@ -49,6 +49,8 @@ HRESULT Direct3D::QueryInterface(
 		str << " " << *obp;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -62,6 +64,8 @@ ULONG Direct3D::AddRef()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -82,6 +86,8 @@ ULONG Direct3D::Release()
 	str << std::endl;
 	str << "\t" << count;
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return count;
 }
@@ -95,6 +101,8 @@ HRESULT Direct3D::Initialize(REFCLSID riid)
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -126,8 +134,12 @@ HRESULT Direct3D::EnumDevices(
 
 	HRESULT hr = this->_original->EnumDevices(EnumDevicesCallback, lpUserArg);
 
-	LogText(tostr_HR(hr));
+	std::ostringstream str2;
+	str2 << std::endl;
+	str2 << tostr_HR(hr);
+	str2 << std::endl << "\treturn to: " << _ReturnAddress();
 
+	LogText(str2.str());
 	return hr;
 }
 
@@ -151,6 +163,8 @@ HRESULT Direct3D::CreateLight(
 	{
 		str << " " << *lplpDirect3DLight;
 	}
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -176,6 +190,8 @@ HRESULT Direct3D::CreateMaterial(
 	{
 		str << " " << *lplpDirect3DMaterial;
 	}
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -204,6 +220,8 @@ HRESULT Direct3D::CreateViewport(
 		str << " " << *lplpD3DViewport;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -222,6 +240,8 @@ HRESULT Direct3D::FindDevice(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;

--- a/ddraw_logger/ddraw/Direct3DDevice.cpp
+++ b/ddraw_logger/ddraw/Direct3DDevice.cpp
@@ -53,6 +53,8 @@ HRESULT Direct3DDevice::QueryInterface(
 		str << " " << *obp;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -66,6 +68,8 @@ ULONG Direct3DDevice::AddRef()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -85,6 +89,8 @@ ULONG Direct3DDevice::Release()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -109,6 +115,8 @@ HRESULT Direct3DDevice::Initialize(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -125,6 +133,8 @@ HRESULT Direct3DDevice::GetCaps(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -155,6 +165,8 @@ HRESULT Direct3DDevice::SwapTextureHandles(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -178,6 +190,8 @@ HRESULT Direct3DDevice::CreateExecuteBuffer(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -193,6 +207,8 @@ HRESULT Direct3DDevice::GetStats(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -232,6 +248,8 @@ HRESULT Direct3DDevice::Execute(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -254,6 +272,8 @@ HRESULT Direct3DDevice::AddViewport(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -275,6 +295,8 @@ HRESULT Direct3DDevice::DeleteViewport(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -314,6 +336,8 @@ HRESULT Direct3DDevice::NextViewport(
 		str << " " << *lplpDirect3DViewport;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -346,6 +370,8 @@ HRESULT Direct3DDevice::Pick(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -362,6 +388,8 @@ HRESULT Direct3DDevice::GetPickRecords(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -396,8 +424,12 @@ HRESULT Direct3DDevice::EnumTextureFormats(
 
 	HRESULT hr = this->_original->EnumTextureFormats(EnumTextureFormatsCallback, lpArg);
 
-	LogText(tostr_HR(hr));
+	std::ostringstream str2;
+	str2 << std::endl;
+	str2 << tostr_HR(hr);
+	str2 << std::endl << "\treturn to: " << _ReturnAddress();
 
+	LogText(str2.str());
 	return hr;
 }
 
@@ -412,6 +444,8 @@ HRESULT Direct3DDevice::CreateMatrix(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -430,6 +464,8 @@ HRESULT Direct3DDevice::SetMatrix(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -447,6 +483,8 @@ HRESULT Direct3DDevice::GetMatrix(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -463,6 +501,8 @@ HRESULT Direct3DDevice::DeleteMatrix(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -477,6 +517,8 @@ HRESULT Direct3DDevice::BeginScene()
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -490,6 +532,8 @@ HRESULT Direct3DDevice::EndScene()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -511,6 +555,8 @@ HRESULT Direct3DDevice::GetDirect3D(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;

--- a/ddraw_logger/ddraw/Direct3DExecuteBuffer.cpp
+++ b/ddraw_logger/ddraw/Direct3DExecuteBuffer.cpp
@@ -49,6 +49,8 @@ HRESULT Direct3DExecuteBuffer::QueryInterface(
 		str << " " << *obp;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -62,6 +64,8 @@ ULONG Direct3DExecuteBuffer::AddRef()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -81,6 +85,8 @@ ULONG Direct3DExecuteBuffer::Release()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -104,6 +110,8 @@ HRESULT Direct3DExecuteBuffer::Initialize(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -120,6 +128,8 @@ HRESULT Direct3DExecuteBuffer::Lock(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -133,6 +143,8 @@ HRESULT Direct3DExecuteBuffer::Unlock()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -150,6 +162,8 @@ HRESULT Direct3DExecuteBuffer::SetExecuteData(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -165,6 +179,8 @@ HRESULT Direct3DExecuteBuffer::GetExecuteData(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -185,6 +201,8 @@ HRESULT Direct3DExecuteBuffer::Validate(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -198,6 +216,8 @@ HRESULT Direct3DExecuteBuffer::Optimize(DWORD dwFlags)
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;

--- a/ddraw_logger/ddraw/Direct3DTexture.cpp
+++ b/ddraw_logger/ddraw/Direct3DTexture.cpp
@@ -50,6 +50,8 @@ HRESULT Direct3DTexture::QueryInterface(
 		str << " " << *obp;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -63,6 +65,8 @@ ULONG Direct3DTexture::AddRef()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -82,6 +86,8 @@ ULONG Direct3DTexture::Release()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -107,6 +113,8 @@ HRESULT Direct3DTexture::Initialize(LPDIRECT3DDEVICE lpD3DDevice, LPDIRECTDRAWSU
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -130,6 +138,8 @@ HRESULT Direct3DTexture::GetHandle(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -146,6 +156,8 @@ HRESULT Direct3DTexture::PaletteChanged(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -169,6 +181,8 @@ HRESULT Direct3DTexture::Load(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -182,6 +196,8 @@ HRESULT Direct3DTexture::Unload()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;

--- a/ddraw_logger/ddraw/Direct3DViewport.cpp
+++ b/ddraw_logger/ddraw/Direct3DViewport.cpp
@@ -50,6 +50,8 @@ HRESULT Direct3DViewport::QueryInterface(
 		str << " " << *obp;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -63,6 +65,8 @@ ULONG Direct3DViewport::AddRef()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -82,6 +86,8 @@ ULONG Direct3DViewport::Release()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -104,6 +110,8 @@ HRESULT Direct3DViewport::Initialize(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -120,6 +128,8 @@ HRESULT Direct3DViewport::GetViewport(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -135,6 +145,8 @@ HRESULT Direct3DViewport::SetViewport(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -155,6 +167,8 @@ HRESULT Direct3DViewport::TransformVertices(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -172,6 +186,8 @@ HRESULT Direct3DViewport::LightElements(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -187,6 +203,8 @@ HRESULT Direct3DViewport::SetBackground(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -204,6 +222,8 @@ HRESULT Direct3DViewport::GetBackground(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -226,6 +246,8 @@ HRESULT Direct3DViewport::SetBackgroundDepth(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -254,6 +276,8 @@ HRESULT Direct3DViewport::GetBackgroundDepth(
 		str << " " << *lplpDDSurface;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -275,6 +299,8 @@ HRESULT Direct3DViewport::Clear(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -294,6 +320,8 @@ HRESULT Direct3DViewport::AddLight(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -316,6 +344,8 @@ HRESULT Direct3DViewport::DeleteLight(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -345,6 +375,8 @@ HRESULT Direct3DViewport::NextLight(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -360,6 +392,8 @@ HRESULT Direct3DViewport::GetViewport2(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -377,6 +411,8 @@ HRESULT Direct3DViewport::SetViewport2(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -392,6 +428,8 @@ HRESULT Direct3DViewport::SetBackgroundDepth2(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -409,6 +447,8 @@ HRESULT Direct3DViewport::GetBackgroundDepth2(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -434,6 +474,8 @@ HRESULT Direct3DViewport::Clear2(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;

--- a/ddraw_logger/ddraw/DirectDraw.cpp
+++ b/ddraw_logger/ddraw/DirectDraw.cpp
@@ -10,6 +10,8 @@
 #include "DirectDrawSurface.h"
 #include "Direct3D.h"
 
+// #include <intrin.h> // test
+
 DirectDraw::DirectDraw(IDirectDraw* original)
 {
 	this->_original = original;
@@ -191,6 +193,8 @@ HRESULT DirectDraw::CreateSurface(
 	str << this << " " << __FUNCTION__;
 	str << tostr_DDSURFACEDESC(lpDDSurfaceDesc);
 
+	/* @TheRedDaemon: removed modification, intention is to see what it normally does, or not?
+
 	if (lpDDSurfaceDesc)
 	{
 		if (lpDDSurfaceDesc->ddsCaps.dwCaps &  DDSCAPS_ZBUFFER)
@@ -203,6 +207,8 @@ HRESULT DirectDraw::CreateSurface(
 			str << tostr_DDSURFACEDESC(lpDDSurfaceDesc);
 		}
 	}
+
+	*/
 
 	HRESULT hr = this->_original->CreateSurface(lpDDSurfaceDesc, lplpDDSurface, pUnkOuter);
 
@@ -218,6 +224,8 @@ HRESULT DirectDraw::CreateSurface(
 	{
 		str << " " << *lplpDDSurface;
 	}
+
+	// str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -519,12 +527,16 @@ HRESULT DirectDraw::SetDisplayMode(
 	str << this << " " << __FUNCTION__;
 	str << " " << dwWidth << "x" << dwHeight << " " << dwBPP;
 
+	/* @TheRedDaemon: removed modification, intention is to see what it normally does, or not?
+
 	dwWidth = GetSystemMetrics(SM_CXSCREEN);
 	dwHeight = GetSystemMetrics(SM_CYSCREEN);
 
 	str << std::endl;
 	str << "\tMODIFIED";
 	str << " " << dwWidth << "x" << dwHeight << " " << dwBPP;
+	
+	*/
 
 	HRESULT hr = this->_original->SetDisplayMode(dwWidth, dwHeight, dwBPP);
 

--- a/ddraw_logger/ddraw/DirectDraw.cpp
+++ b/ddraw_logger/ddraw/DirectDraw.cpp
@@ -10,8 +10,6 @@
 #include "DirectDrawSurface.h"
 #include "Direct3D.h"
 
-// #include <intrin.h> // test
-
 DirectDraw::DirectDraw(IDirectDraw* original)
 {
 	this->_original = original;
@@ -68,6 +66,8 @@ HRESULT DirectDraw::QueryInterface(
 		str << " " << *obp;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -81,6 +81,8 @@ ULONG DirectDraw::AddRef()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -101,6 +103,8 @@ ULONG DirectDraw::Release()
 	str << std::endl;
 	str << "\t" << count;
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return count;
 }
@@ -114,6 +118,8 @@ HRESULT DirectDraw::Compact()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -142,6 +148,8 @@ HRESULT DirectDraw::CreateClipper(
 	{
 		str << " " << *lplpDDClipper;
 	}
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -178,6 +186,8 @@ HRESULT DirectDraw::CreatePalette(
 	{
 		str << " " << *lplpDDPalette;
 	}
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -225,7 +235,7 @@ HRESULT DirectDraw::CreateSurface(
 		str << " " << *lplpDDSurface;
 	}
 
-	// str << std::endl << "\treturn to: " << _ReturnAddress();
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -260,6 +270,8 @@ HRESULT DirectDraw::DuplicateSurface(
 		str << " " << *lplpDupDDSurface;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -273,7 +285,6 @@ static HRESULT CALLBACK EnumModesCallback(LPDDSURFACEDESC lpDDSurfaceDesc, LPVOI
 	str << tostr_DDSURFACEDESC(lpDDSurfaceDesc);
 
 	LogText(str.str());
-
 	return s_lpEnumModesCallback(lpDDSurfaceDesc, lpContext);
 }
 
@@ -293,8 +304,12 @@ HRESULT DirectDraw::EnumDisplayModes(
 
 	HRESULT hr = this->_original->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, lpContext, EnumModesCallback);
 
-	LogText(tostr_HR(hr));
+	std::ostringstream str2;
+	str2 << std::endl;
+	str2 << tostr_HR(hr);
+	str2 << std::endl << "\treturn to: " << _ReturnAddress();
 
+	LogText(str2.str());
 	return hr;
 }
 
@@ -316,6 +331,8 @@ HRESULT DirectDraw::EnumSurfaces(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -329,6 +346,8 @@ HRESULT DirectDraw::FlipToGDISurface()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -347,6 +366,8 @@ HRESULT DirectDraw::GetCaps(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -362,6 +383,8 @@ HRESULT DirectDraw::GetDisplayMode(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -379,6 +402,8 @@ HRESULT DirectDraw::GetFourCCCodes(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -406,6 +431,8 @@ HRESULT DirectDraw::GetGDISurface(
 		str << " " << *lplpGDIDDSSurface;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -421,6 +448,8 @@ HRESULT DirectDraw::GetMonitorFrequency(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -438,6 +467,8 @@ HRESULT DirectDraw::GetScanLine(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -453,6 +484,8 @@ HRESULT DirectDraw::GetVerticalBlankStatus(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -471,6 +504,8 @@ HRESULT DirectDraw::Initialize(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -484,6 +519,8 @@ HRESULT DirectDraw::RestoreDisplayMode()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -512,6 +549,8 @@ HRESULT DirectDraw::SetCooperativeLevel(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -543,6 +582,8 @@ HRESULT DirectDraw::SetDisplayMode(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -563,6 +604,8 @@ HRESULT DirectDraw::WaitForVerticalBlank(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;

--- a/ddraw_logger/ddraw/DirectDraw2.cpp
+++ b/ddraw_logger/ddraw/DirectDraw2.cpp
@@ -51,6 +51,8 @@ HRESULT DirectDraw2::QueryInterface(
 		str << " " << *obp;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -64,6 +66,8 @@ ULONG DirectDraw2::AddRef()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -84,6 +88,8 @@ ULONG DirectDraw2::Release()
 	str << std::endl;
 	str << "\t" << count;
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return count;
 }
@@ -97,6 +103,8 @@ HRESULT DirectDraw2::Compact()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -125,6 +133,8 @@ HRESULT DirectDraw2::CreateClipper(
 	{
 		str << " " << *lplpDDClipper;
 	}
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -162,6 +172,8 @@ HRESULT DirectDraw2::CreatePalette(
 		str << " " << *lplpDDPalette;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -190,6 +202,8 @@ HRESULT DirectDraw2::CreateSurface(
 	{
 		str << " " << *lplpDDSurface;
 	}
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -224,6 +238,8 @@ HRESULT DirectDraw2::DuplicateSurface(
 		str << " " << *lplpDupDDSurface;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -257,8 +273,12 @@ HRESULT DirectDraw2::EnumDisplayModes(
 
 	HRESULT hr = this->_original->EnumDisplayModes(dwFlags, lpDDSurfaceDesc, lpContext, EnumModesCallback);
 
-	LogText(tostr_HR(hr));
+	std::ostringstream str2;
+	str2 << std::endl;
+	str2 << tostr_HR(hr);
+	str2 << std::endl << "\treturn to: " << _ReturnAddress();
 
+	LogText(str2.str());
 	return hr;
 }
 
@@ -280,6 +300,8 @@ HRESULT DirectDraw2::EnumSurfaces(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -293,6 +315,8 @@ HRESULT DirectDraw2::FlipToGDISurface()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -311,6 +335,8 @@ HRESULT DirectDraw2::GetCaps(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -326,6 +352,8 @@ HRESULT DirectDraw2::GetDisplayMode(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -343,6 +371,8 @@ HRESULT DirectDraw2::GetFourCCCodes(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -370,6 +400,8 @@ HRESULT DirectDraw2::GetGDISurface(
 		str << " " << *lplpGDIDDSSurface;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -385,6 +417,8 @@ HRESULT DirectDraw2::GetMonitorFrequency(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -402,6 +436,8 @@ HRESULT DirectDraw2::GetScanLine(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -417,6 +453,8 @@ HRESULT DirectDraw2::GetVerticalBlankStatus(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -435,6 +473,8 @@ HRESULT DirectDraw2::Initialize(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -448,6 +488,8 @@ HRESULT DirectDraw2::RestoreDisplayMode()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -477,6 +519,8 @@ HRESULT DirectDraw2::SetCooperativeLevel(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -497,6 +541,8 @@ HRESULT DirectDraw2::SetDisplayMode(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -519,6 +565,8 @@ HRESULT DirectDraw2::WaitForVerticalBlank(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -536,6 +584,8 @@ HRESULT DirectDraw2::GetAvailableVidMem(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;

--- a/ddraw_logger/ddraw/DirectDraw4.cpp
+++ b/ddraw_logger/ddraw/DirectDraw4.cpp
@@ -50,6 +50,8 @@ HRESULT DirectDraw4::QueryInterface(
 		str << " " << *obp;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -63,6 +65,8 @@ ULONG DirectDraw4::AddRef()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -83,6 +87,8 @@ ULONG DirectDraw4::Release()
 	str << std::endl;
 	str << "\t" << count;
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return count;
 }
@@ -96,6 +102,8 @@ HRESULT DirectDraw4::Compact()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -124,6 +132,8 @@ HRESULT DirectDraw4::CreateClipper(
 	{
 		str << " " << *lplpDDClipper;
 	}
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -161,6 +171,8 @@ HRESULT DirectDraw4::CreatePalette(
 		str << " " << *lplpDDPalette;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -181,6 +193,8 @@ HRESULT DirectDraw4::CreateSurface(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -205,6 +219,8 @@ HRESULT DirectDraw4::DuplicateSurface(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -227,10 +243,13 @@ HRESULT DirectDraw4::EnumDisplayModes(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
 
+// @TheRedDaemon: No log for callback function here?
 HRESULT DirectDraw4::EnumSurfaces(
 	DWORD dwFlags,
 	LPDDSURFACEDESC2 lpDDSD,
@@ -249,6 +268,8 @@ HRESULT DirectDraw4::EnumSurfaces(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -262,6 +283,8 @@ HRESULT DirectDraw4::FlipToGDISurface()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -280,6 +303,8 @@ HRESULT DirectDraw4::GetCaps(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -295,6 +320,8 @@ HRESULT DirectDraw4::GetDisplayMode(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -312,6 +339,8 @@ HRESULT DirectDraw4::GetFourCCCodes(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -332,6 +361,8 @@ HRESULT DirectDraw4::GetGDISurface(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -347,6 +378,8 @@ HRESULT DirectDraw4::GetMonitorFrequency(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -364,6 +397,8 @@ HRESULT DirectDraw4::GetScanLine(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -379,6 +414,8 @@ HRESULT DirectDraw4::GetVerticalBlankStatus(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -397,6 +434,8 @@ HRESULT DirectDraw4::Initialize(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -410,6 +449,8 @@ HRESULT DirectDraw4::RestoreDisplayMode()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -439,6 +480,8 @@ HRESULT DirectDraw4::SetCooperativeLevel(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -459,6 +502,8 @@ HRESULT DirectDraw4::SetDisplayMode(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -481,6 +526,8 @@ HRESULT DirectDraw4::WaitForVerticalBlank(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -498,6 +545,8 @@ HRESULT DirectDraw4::GetAvailableVidMem(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -519,6 +568,8 @@ HRESULT DirectDraw4::GetSurfaceFromDC(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -533,6 +584,8 @@ HRESULT DirectDraw4::RestoreAllSurfaces()
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -546,6 +599,8 @@ HRESULT DirectDraw4::TestCooperativeLevel()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -563,6 +618,8 @@ HRESULT DirectDraw4::GetDeviceIdentifier(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;

--- a/ddraw_logger/ddraw/DirectDrawClipper.cpp
+++ b/ddraw_logger/ddraw/DirectDrawClipper.cpp
@@ -49,6 +49,8 @@ HRESULT DirectDrawClipper::QueryInterface(
 		str << " " << *obp;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -62,6 +64,8 @@ ULONG DirectDrawClipper::AddRef()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -82,6 +86,8 @@ ULONG DirectDrawClipper::Release()
 	str << std::endl;
 	str << "\t" << count;
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return count;
 }
@@ -100,6 +106,8 @@ HRESULT DirectDrawClipper::GetClipList(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -115,6 +123,8 @@ HRESULT DirectDrawClipper::GetHWnd(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -138,6 +148,8 @@ HRESULT DirectDrawClipper::Initialize(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -153,6 +165,8 @@ HRESULT DirectDrawClipper::IsClipListChanged(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -171,6 +185,8 @@ HRESULT DirectDrawClipper::SetClipList(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -187,6 +203,8 @@ HRESULT DirectDrawClipper::SetHWnd(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;

--- a/ddraw_logger/ddraw/DirectDrawPalette.cpp
+++ b/ddraw_logger/ddraw/DirectDrawPalette.cpp
@@ -49,6 +49,8 @@ HRESULT DirectDrawPalette::QueryInterface(
 		str << " " << *obp;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -62,6 +64,8 @@ ULONG DirectDrawPalette::AddRef()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -82,6 +86,8 @@ ULONG DirectDrawPalette::Release()
 	str << std::endl;
 	str << "\t" << count;
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return count;
 }
@@ -97,6 +103,8 @@ HRESULT DirectDrawPalette::GetCaps(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -116,6 +124,8 @@ HRESULT DirectDrawPalette::GetEntries(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -140,6 +150,8 @@ HRESULT DirectDrawPalette::Initialize(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -158,6 +170,8 @@ HRESULT DirectDrawPalette::SetEntries(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;

--- a/ddraw_logger/ddraw/DirectDrawSurface.cpp
+++ b/ddraw_logger/ddraw/DirectDrawSurface.cpp
@@ -61,6 +61,8 @@ HRESULT DirectDrawSurface::QueryInterface(
 		str << " " << *obp;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -74,6 +76,8 @@ ULONG DirectDrawSurface::AddRef()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -93,6 +97,8 @@ ULONG DirectDrawSurface::Release()
 
 	str << std::endl;
 	str << "\t" << count;
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return count;
@@ -116,6 +122,8 @@ HRESULT DirectDrawSurface::AddAttachedSurface(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -132,6 +140,8 @@ HRESULT DirectDrawSurface::AddOverlayDirtyRect(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -231,6 +241,8 @@ HRESULT DirectDrawSurface::Blt(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -251,6 +263,8 @@ HRESULT DirectDrawSurface::BltBatch(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -286,6 +300,8 @@ HRESULT DirectDrawSurface::BltFast(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -309,6 +325,8 @@ HRESULT DirectDrawSurface::DeleteAttachedSurface(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -328,6 +346,8 @@ HRESULT DirectDrawSurface::EnumAttachedSurfaces(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -353,6 +373,8 @@ HRESULT DirectDrawSurface::EnumOverlayZOrders(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -380,6 +402,8 @@ HRESULT DirectDrawSurface::Flip(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -440,6 +464,8 @@ HRESULT DirectDrawSurface::GetAttachedSurface(
 		str << " " << *lplpDDAttachedSurface;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -459,6 +485,8 @@ HRESULT DirectDrawSurface::GetBltStatus(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -474,6 +502,8 @@ HRESULT DirectDrawSurface::GetCaps(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -501,6 +531,8 @@ HRESULT DirectDrawSurface::GetClipper(
 		str << " " << *lplpDDClipper;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -523,6 +555,8 @@ HRESULT DirectDrawSurface::GetColorKey(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -538,6 +572,8 @@ HRESULT DirectDrawSurface::GetDC(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -558,6 +594,8 @@ HRESULT DirectDrawSurface::GetFlipStatus(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -574,6 +612,8 @@ HRESULT DirectDrawSurface::GetOverlayPosition(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -601,6 +641,8 @@ HRESULT DirectDrawSurface::GetPalette(
 		str << " " << *lplpDDPalette;
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -616,6 +658,8 @@ HRESULT DirectDrawSurface::GetPixelFormat(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -637,6 +681,8 @@ HRESULT DirectDrawSurface::GetSurfaceDesc(
 	{
 		str << tostr_DDSURFACEDESC(lpDDSurfaceDesc);
 	}
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -660,6 +706,8 @@ HRESULT DirectDrawSurface::Initialize(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -673,6 +721,8 @@ HRESULT DirectDrawSurface::IsLost()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -705,6 +755,8 @@ HRESULT DirectDrawSurface::Lock(
 		str << tostr_DDSURFACEDESC(lpDDSurfaceDesc);
 	}
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -721,6 +773,8 @@ HRESULT DirectDrawSurface::ReleaseDC(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -734,6 +788,8 @@ HRESULT DirectDrawSurface::Restore()
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -756,6 +812,8 @@ HRESULT DirectDrawSurface::SetClipper(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -780,6 +838,8 @@ HRESULT DirectDrawSurface::SetColorKey(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -796,6 +856,8 @@ HRESULT DirectDrawSurface::SetOverlayPosition(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -818,6 +880,8 @@ HRESULT DirectDrawSurface::SetPalette(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -833,6 +897,8 @@ HRESULT DirectDrawSurface::Unlock(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -886,6 +952,8 @@ HRESULT DirectDrawSurface::UpdateOverlay(
 	str << std::endl;
 	str << tostr_HR(hr);
 
+	str << std::endl << "\treturn to: " << _ReturnAddress();
+
 	LogText(str.str());
 	return hr;
 }
@@ -904,6 +972,8 @@ HRESULT DirectDrawSurface::UpdateOverlayDisplay(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;
@@ -955,6 +1025,8 @@ HRESULT DirectDrawSurface::UpdateOverlayZOrder(
 
 	str << std::endl;
 	str << tostr_HR(hr);
+
+	str << std::endl << "\treturn to: " << _ReturnAddress();
 
 	LogText(str.str());
 	return hr;

--- a/ddraw_logger/ddraw/common.h
+++ b/ddraw_logger/ddraw/common.h
@@ -16,3 +16,6 @@
 #include "wrapper.h"
 #include "logger.h"
 #include "utils.h"
+
+// @TheRedDaemon: get return address with _ReturnAddress
+#include <intrin.h>

--- a/ddraw_logger/ddraw/ddraw.vcxproj
+++ b/ddraw_logger/ddraw/ddraw.vcxproj
@@ -60,18 +60,19 @@
     <ProjectGuid>{13934377-EED9-4816-8003-89794467391D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ddraw</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>NotSet</CharacterSet>
   </PropertyGroup>

--- a/ddraw_logger/ddraw/utils.cpp
+++ b/ddraw_logger/ddraw/utils.cpp
@@ -147,6 +147,16 @@ std::string tostr_GUID(const GUID* lpGUID)
 	{
 		return " NULL";
 	}
+	
+	if ((DWORD)lpGUID == DDCREATE_EMULATIONONLY)
+	{
+		return " DDCREATE_EMULATIONONLY";
+	}
+
+	if ((DWORD)lpGUID == DDCREATE_HARDWAREONLY)
+	{
+		return " DDCREATE_HARDWAREONLY";
+	}
 
 	TOSTR_IID(IUnknown);
 	TOSTR_IID(IDirectDraw);


### PR DESCRIPTION
* The two possible GUID flags DDCREATE_EMULATIONONLY and DDCREATE_HARDWAREONLY were not handled before.
* Resolution Modification caused issues at least with the game "Stronghold Crusader"
* Return address is received by using the intrinsic [_ReturnAddress](https://docs.microsoft.com/en-us/cpp/intrinsics/returnaddress?view=msvc-160).
  * Found no method to get application call address of exported functions.